### PR TITLE
Fixed py26 dependency

### DIFF
--- a/Polymode/mathlink/setup.py
+++ b/Polymode/mathlink/setup.py
@@ -11,7 +11,7 @@ _ublock_boost_prefix = None
 
 #USYD
 _ublock_boost_prefix = "/users/amstaff/andrewd/usr"
-_ublock_boost_lib = "boost_python-py26"
+_ublock_boost_lib = "boost_python"
 
 #Windows:
 #_ublock_boost_prefix = "c:\Boost"


### PR DESCRIPTION
Dear sir,

Nice project! 

I had a bit of a hard time installing it because it depends on boost_python-26. As fas as I can see this can be substituted nowadays with libboost-python to enable the package to run under python 2.7. I don't know what the _ublock_boost_prefix does, but I did not need to change it as fas as I can see.

Regards,

Dirk Boonzajer